### PR TITLE
Replace Home URL to Site directory URL

### DIFF
--- a/includes/classes/wp-maintenance-mode.php
+++ b/includes/classes/wp-maintenance-mode.php
@@ -480,7 +480,7 @@ if (!class_exists('WP_Maintenance_Mode')) {
                 // JS FILES
                 $wp_scripts = new WP_Scripts();
                 $scripts = array(
-                    'jquery' => !empty($wp_scripts->registered['jquery-core']) ? home_url($wp_scripts->registered['jquery-core']->src) : '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js',
+                    'jquery' => !empty($wp_scripts->registered['jquery-core']) ? site_url($wp_scripts->registered['jquery-core']->src) : '//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js',
                     'frontend' => WPMM_JS_URL . 'scripts.js'
                 );
                 if (!empty($this->plugin_settings['modules']['countdown_status']) && $this->plugin_settings['modules']['countdown_status'] == 1) {


### PR DESCRIPTION
Because `site_url()` return http://www.example.com or http://www.example.com/wordpress if WordPress has been installed in a subfolder.