### PR TITLE
Do not throw maintenance nag when called from wp-cli

### DIFF
--- a/includes/classes/wp-maintenance-mode.php
+++ b/includes/classes/wp-maintenance-mode.php
@@ -430,7 +430,8 @@ if (!class_exists('WP_Maintenance_Mode')) {
                     !strstr($_SERVER['PHP_SELF'], '/plugins/') &&
                     !strstr($_SERVER['PHP_SELF'], '/xmlrpc.php') &&
                     !$this->check_exclude() &&
-                    !$this->check_search_bots()
+		    !$this->check_search_bots() &&
+		    !defined('WP_CLI')
             ) {
                 // HEADER STUFF
                 $protocol = !empty($_SERVER['SERVER_PROTOCOL']) && in_array($_SERVER['SERVER_PROTOCOL'], array('HTTP/1.1', 'HTTP/1.0')) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';


### PR DESCRIPTION
When worpdress is called from the command line with wp-cli and this plugin is activated, maintenance page is thrown and execution stopped unless we specify an authorized user.

This PR simply prevent the plugin to block execution if wordpress is called from wp-cli. More info on wp-cli here: https://github.com/wp-cli/wp-cli