### PR TITLE
Filter for excluded rules

### DIFF
--- a/includes/classes/wp-maintenance-mode.php
+++ b/includes/classes/wp-maintenance-mode.php
@@ -608,15 +608,19 @@ if (!class_exists('WP_Maintenance_Mode')) {
          */
         public function check_exclude() {
             $is_excluded = false;
+            $exclude_list = null;
 
             if (!empty($this->plugin_settings['general']['exclude']) && is_array($this->plugin_settings['general']['exclude'])) {
-                foreach ($this->plugin_settings['general']['exclude'] as $item) {
+                $exclude_list = $this->plugin_settings['general']['exclude'];
+                foreach ($exclude_list as $item) {
                     if ((!empty($_SERVER['REMOTE_ADDR']) && strstr($_SERVER['REMOTE_ADDR'], $item)) || (!empty($_SERVER['REQUEST_URI']) && strstr($_SERVER['REQUEST_URI'], $item))) {
                         $is_excluded = true;
                         break;
                     }
                 }
             }
+
+            $is_exclude = apply_filters('wp_maintenance_mode_exclude', $is_excluded, $exclude_list);
 
             return $is_excluded;
         }

--- a/includes/classes/wp-maintenance-mode.php
+++ b/includes/classes/wp-maintenance-mode.php
@@ -608,11 +608,11 @@ if (!class_exists('WP_Maintenance_Mode')) {
          */
         public function check_exclude() {
             $is_excluded = false;
-            $exclude_list = null;
+            $excluded_list = null;
 
             if (!empty($this->plugin_settings['general']['exclude']) && is_array($this->plugin_settings['general']['exclude'])) {
-                $exclude_list = $this->plugin_settings['general']['exclude'];
-                foreach ($exclude_list as $item) {
+                $excluded_list = $this->plugin_settings['general']['exclude'];
+                foreach ($excluded_list as $item) {
                     if ((!empty($_SERVER['REMOTE_ADDR']) && strstr($_SERVER['REMOTE_ADDR'], $item)) || (!empty($_SERVER['REQUEST_URI']) && strstr($_SERVER['REQUEST_URI'], $item))) {
                         $is_excluded = true;
                         break;
@@ -620,7 +620,7 @@ if (!class_exists('WP_Maintenance_Mode')) {
                 }
             }
 
-            $is_exclude = apply_filters('wp_maintenance_mode_exclude', $is_excluded, $exclude_list);
+            $is_excluded = apply_filters('wp_maintenance_mode_exclude', $is_excluded, $excluded_list);
 
             return $is_excluded;
         }


### PR DESCRIPTION
I runned into a problem that the plugin wasn't working with the users IP because the webserver was behind a proxy. So the users IP was in X-FORWARDED-FOR instead of REMOTE _ADDR. To fix it I put the $is_excluded through a filter. With an add_filter in a custom plugin I was able to do an own check.