### PR TITLE
Add action after body

### DIFF
--- a/views/maintenance.php
+++ b/views/maintenance.php
@@ -25,6 +25,10 @@
         ?>
     </head>
     <body class="<?php echo $body_classes ? $body_classes : ''; ?>">
+        <?php 
+        // do some actions
+        do_action('wpmm_after_body');
+        ?>
         <div class="wrap">
             <?php if (!empty($heading)) { ?><h1><?php echo stripslashes($heading); ?></h1><?php } ?>
             <?php if (!empty($text)) { ?><h2><?php echo stripslashes($text); ?></h2><?php } ?>


### PR DESCRIPTION
Adds action 'wpmm_after_body' after the opening body tag - useful for hooking support for all those tracking pixels and Google Tag Managers.
